### PR TITLE
#include " versus #include <

### DIFF
--- a/EmbAJAX.h
+++ b/EmbAJAX.h
@@ -696,16 +696,16 @@ protected:
 // If the user has not #includ'ed a specific output driver implementation, make a good guess, here
 #if not defined (EMBAJAX_OUTUPUTDRIVER_IMPLEMENTATION)
 #if defined (ESP8266)
-#include <EmbAJAXOutputDriverESP8266.h>
+#include "EmbAJAXOutputDriverESP8266.h"
 #elif defined (ESP32)
-#include <EmbAJAXOutputDriverESP32.h>
+#include "EmbAJAXOutputDriverESP32.h"
 #elif defined (ARDUINO_ARCH_RP2040)
-#include <EmbAJAXOutputDriverRP2040.h>
+#include "EmbAJAXOutputDriverRP2040.h"
 #else
 #include <WebServer.h>
 #define EmbAJAXOutputDriverWebServerClass WebServer
 #include <WiFi.h>
-#include <EmbAJAXOutputDriverGeneric.h>
+#include "EmbAJAXOutputDriverGeneric.h"
 #warning No output driver available for this hardware (yet). We try using the generic driver, but success is not guaranteed.
 #warning In most cases, implementing a driver is as easy as picking the correct header file to include. Please consider submitting a patch.
 #endif

--- a/EmbAJAXJoystick.h
+++ b/EmbAJAXJoystick.h
@@ -22,7 +22,7 @@
 #ifndef EMBAJAXJOYSTICK_H
 #define EMBAJAXJOYSTICK_H
 
-#include <EmbAJAX.h>
+#include "EmbAJAX.h"
 
 const char EmbAJAXJoystick_SNAP_BACK[] = "if (!pressed) { x = 0; y = 0; }\n";
 const char EmbAJAXJoystick_NO_SNAP_BACK[] = "";

--- a/EmbAJAXScriptedSpan.h
+++ b/EmbAJAXScriptedSpan.h
@@ -22,7 +22,7 @@
 #ifndef EMBAJAXSCRIPTEDSPAN_H
 #define EMBAJAXSCRIPTEDSPAN_H
 
-#include <EmbAJAX.h>
+#include "EmbAJAX.h"
 
 /** @brief A span element containing a custom javascript script, meant to creating custom dispays
  * 

--- a/EmbAJAXValidatingTextInput.h
+++ b/EmbAJAXValidatingTextInput.h
@@ -22,7 +22,7 @@
 #ifndef EMBAJAXVALIDATINGTEXTINPUT_H
 #define EMBAJAXVALIDATINGTEXTINPUT_H
 
-#include <EmbAJAX.h>
+#include "EmbAJAX.h"
 
 template<size_t SIZE> class EmbAJAXValidatingTextInput : public EmbAJAXTextInput<SIZE> {
 public:

--- a/examples/Blink/Blink.ino
+++ b/examples/Blink/Blink.ino
@@ -8,7 +8,7 @@
  * 
  * This example code is in the public domain (CONTRARY TO THE LIBRARY ITSELF). */
 
-#include <EmbAJAX.h>
+#include "EmbAJAX.h"
 
 #define LEDPIN LED_BUILTIN
 

--- a/examples/Inputs/Inputs.ino
+++ b/examples/Inputs/Inputs.ino
@@ -5,9 +5,9 @@
 * 
 * This example code is in the public domain (CONTRARY TO THE LIBRARY ITSELF). */
 
-#include <EmbAJAX.h>
-#include <EmbAJAXValidatingTextInput.h> // Fancier text input in a separate header file
-#include <EmbAJAXScriptedSpan.h>
+#include "EmbAJAX.h"
+#include "EmbAJAXValidatingTextInput.h" // Fancier text input in a separate header file
+#include "EmbAJAXScriptedSpan.h"
 
 // Set up web server, and register it with EmbAJAX. Note: EmbAJAXOutputDriverWebServerClass is a
 // convenience #define to allow using the same example code across platforms

--- a/examples/Joystick/Joystick.ino
+++ b/examples/Joystick/Joystick.ino
@@ -8,8 +8,8 @@
  * 
  * This example code is in the public domain (CONTRARY TO THE LIBRARY ITSELF). */
 
-#include <EmbAJAX.h>
-#include <EmbAJAXJoystick.h>
+#include "EmbAJAX.h"
+#include "EmbAJAXJoystick.h"
 
 // Set up web server, and register it with EmbAJAX. Note: EmbAJAXOutputDriverWebServerClass is a
 // convenience #define to allow using the same example code across platforms

--- a/examples/Styling/Styling.ino
+++ b/examples/Styling/Styling.ino
@@ -8,7 +8,7 @@
  *
  * This example code is in the public domain (CONTRARY TO THE LIBRARY ITSELF). */
 
-#include <EmbAJAX.h>
+#include "EmbAJAX.h"
 
 // Set up web server, and register it with EmbAJAX. Note: EmbAJAXOutputDriverWebServerClass is a
 // convenience #define to allow using the same example code across platforms

--- a/examples/TwoPages/TwoPages.ino
+++ b/examples/TwoPages/TwoPages.ino
@@ -3,7 +3,7 @@
  * 
  * This example code is in the public domain (CONTRARY TO THE LIBRARY ITSELF). */
 
-#include <EmbAJAX.h>
+#include "EmbAJAX.h"
 
 #define LEDPIN LED_BUILTIN
 

--- a/examples/Visibility/Visibility.ino
+++ b/examples/Visibility/Visibility.ino
@@ -5,7 +5,7 @@
 * 
 * This example code is in the public domain (CONTRARY TO THE LIBRARY ITSELF). */
 
-#include <EmbAJAX.h>
+#include "EmbAJAX.h"
 
 // Set up web server, and register it with EmbAJAX. Note: EmbAJAXOutputDriverWebServerClass is a
 // convenience #define to allow using the same example code across platforms


### PR DESCRIPTION
In the library and the examples, the way EmbAjax header files are included is not consistent: sometimes the includes are local, sometimes they are included from the system directory. In case the library exists both locally and in the system directory, the two versions get mixed up as a result.

So I propose to make them all consistent. In the PR they are all local.